### PR TITLE
feat: auto-assign uptime incidents to markscholman

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -2,6 +2,12 @@
 owner: MyFoodForest # Your GitHub organization or username, where this repository lives
 repo: status # The name of this repository
 
+# Auto-assign every incident issue to Mark so GitHub notifies him on downtime.
+# (Observability plan 5, 2026-07-15: GitHub-issue-assignee alerting — no SMTP; the
+# Teams Workflow is Azure-Monitor-schema-shaped and would not render Upptime's payload.)
+assignees:
+  - markscholman
+
 sites:
   - name: Public website
     url: https://www.myfoodforest.nl

--- a/history/admin-portal.yml
+++ b/history/admin-portal.yml
@@ -1,7 +1,7 @@
 url: https://admin.myfoodforest.io
 status: up
 code: 200
-responseTime: 822
-lastUpdated: 2026-07-14T23:16:48.182Z
+responseTime: 781
+lastUpdated: 2026-07-15T09:02:06.342Z
 startTime: 2026-06-12T19:20:36.501Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/my-food-forest-api.yml
+++ b/history/my-food-forest-api.yml
@@ -1,7 +1,7 @@
 url: https://api.myfoodforest.io/health
 status: up
 code: 200
-responseTime: 714
-lastUpdated: 2026-07-14T23:16:46.625Z
+responseTime: 686
+lastUpdated: 2026-07-15T09:02:04.779Z
 startTime: 2026-06-12T19:20:34.474Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/plant-database-api.yml
+++ b/history/plant-database-api.yml
@@ -1,7 +1,7 @@
 url: https://plants.myfoodforest.io/health
 status: up
 code: 200
-responseTime: 681
-lastUpdated: 2026-07-14T23:16:47.333Z
+responseTime: 728
+lastUpdated: 2026-07-15T09:02:05.533Z
 startTime: 2026-06-12T19:20:35.506Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/public-website.yml
+++ b/history/public-website.yml
@@ -1,7 +1,7 @@
 url: https://www.myfoodforest.nl
 status: up
 code: 200
-responseTime: 2453
-lastUpdated: 2026-07-14T23:16:45.876Z
+responseTime: 1215
+lastUpdated: 2026-07-15T09:02:04.061Z
 startTime: 2026-06-12T19:20:31.734Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Final observability phase (plan 5). Upptime opens a GitHub issue on every downtime incident; adding `assignees: [markscholman]` auto-assigns those issues so Mark is notified by GitHub email/web.

Per Mark's decision (2026-07-15): GitHub-issue-assignee alerting only — no SMTP (no relay creds) and no Teams (the existing Teams Workflow is shaped for Azure Monitor's common alert schema and would render Upptime's payload as blanks). Monitors unchanged — the 4 live prd URLs; beta.myfoodforest.app + plantdatabase.myfoodforest.io stay deferred until they're actually live (issue #78).

Merging has no deploy side effect; Upptime picks up the config on its next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)